### PR TITLE
Fix bug in MakeCylinder2d when angles are close

### DIFF
--- a/Codes1.1/Codes2D/MakeCylinder2D.m
+++ b/Codes1.1/Codes2D/MakeCylinder2D.m
@@ -52,9 +52,14 @@ for n=1:NCurveFaces  % deform specified faces
   % move vertices at end points of this face to the cylinder
   theta1 = atan2(y1-yo, x1-xo); theta2 = atan2(y2-yo, x2-xo);
 
-  % check to make sure they are in the same quadrant
-  if ((theta2 > 0) & (theta1 < 0)), theta1 = theta1 + 2*pi; end;
-  if ((theta1 > 0) & (theta2 < 0)), theta2 = theta2 + 2*pi; end;
+  % choose the smallest angle between the points
+  while abs(theta1 - theta2) > pi
+    if (theta1 > theta2)
+      theta1 = theta1 - 2*pi;
+    else
+      theta2 = theta2 - 2*pi;
+    end
+  end
   
   % distribute N+1 nodes by arc-length along edge
   theta = 0.5*theta1*(1-fr) + 0.5*theta2*(1+fr);


### PR DESCRIPTION
Ran into a problem with `MakeCylinder2d` when the angles were different signs but still close enough together (one of the angles was close to zero, but had the opposite sign and adding `2*pi` too it to a reflex angle). I think that really you want to check that the distance between the angles is less than `pi` and not worry about the sign difference. (I don't think that the `while` loop will evaluate `true` more than once and so could be replaced with an `if` statement.)